### PR TITLE
Fixes #86: require SUDO_USER to prevent downstream issues

### DIFF
--- a/setup/benchmarks/microsd-benchmarks.sh
+++ b/setup/benchmarks/microsd-benchmarks.sh
@@ -26,6 +26,12 @@ if [ -n "$CLOCK" ]; then
 fi
 printf "\n"
 
+# Environment. We currently depend on SUDO_USER. 
+if [ -z "$SUDO_USER" ]; then
+  printf "!!! SUDO_USER not defined.  Script must be run using sudo.  Exiting.\n\n"
+  exit 1;
+fi
+
 # Variables.
 USER_HOME_PATH=$(getent passwd $SUDO_USER | cut -d: -f6)
 IOZONE_INSTALL_PATH=$USER_HOME_PATH


### PR DESCRIPTION
Simply print message and exit if $SUDO_USER is not defined.    The prevents 'getent passwd' from returning every account home dir, which eventually is passed to 'rm'

I may have oversold the issue a bit.... since the downstream delete is not recursive it should generally just print errors. But still, it's worth avoiding calling  'rm -f  [every home dir]'.

(please forgive any github/collaborative faux pas... I'm new to this  workflow). 