### PR TITLE
Add build prereqs libbf-dev and libssl-dev

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -16,6 +16,8 @@
         name:
           - sudo
           - openssh-server
+          - libffi-dev
+          - libssl-dev
         state: present
 
     - import_tasks: tasks/cgroup-features.yml


### PR DESCRIPTION
I tried a number of clean builds - reformatting the sdcards and following through the steps. Had to include these libraries before it would complete without errors. libffi-dev and libssl-dev . It's possible I missed some config step- but I looked around and didn't see something that looked right.

kube1                      : ok=103  changed=39   unreachable=0    failed=0    skipped=56   rescued=0    ignored=0   
kube2                      : ok=57   changed=19   unreachable=0    failed=0    skipped=41   rescued=0    ignored=0   
kube3                      : ok=57   changed=19   unreachable=0    failed=0    skipped=41   rescued=0    ignored=0   
kube4                      : ok=57   changed=19   unreachable=0    failed=0    skipped=41   rescued=0    ignored=0