### PR TITLE
setup/networking changes

### DIFF
--- a/setup/networking/example.vars.yml
+++ b/setup/networking/example.vars.yml
@@ -16,5 +16,7 @@ mac_address_mapping:
 
 # Nameservers to use in resolv.conf.
 dns_nameservers:
-  - "8.8.8.8"
-  - "8.8.4.4"
+  - "1.1.1.1"
+  - "1.0.0.1"
+
+default_gateway: 10.0.100.1

--- a/setup/networking/get-ip-from-mac-addr.sh
+++ b/setup/networking/get-ip-from-mac-addr.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#
+# Simple helper script to get IP addresses from a Mac Address
+# This needs to use arp-scan because of the differences in the `arp` command output on Linux/MacOS
+#
+
+# Install arp-can
+#   Linux: sudo apt-get install arp-scan
+#   MacOS: brew install arp-scan
+
+# Replace Mac Addresses below with yours
+mac_addresses=(dc:a6:32:00:81:c6 dc:a6:32:05:1a:09 dc:a6:32:05:32:72)
+
+for mac_address in "${mac_addresses[@]}"  
+do
+    ip=$(sudo arp-scan -l | grep "${mac_address}" | awk '{print $1}')
+    echo "mac address ${mac_address} is a registered to ip ${ip}"
+done

--- a/setup/networking/main.yml
+++ b/setup/networking/main.yml
@@ -22,7 +22,7 @@
         mode: 0644
 
     - name: Run hostname command
-      command: "hostname {{ bramble_hostname }}"
+      command: "hostname {{ dramble_hostname }}"
 
     - name: Update /etc/dhcpcd.conf
       template:

--- a/setup/networking/main.yml
+++ b/setup/networking/main.yml
@@ -15,28 +15,23 @@
         dramble_hostname: "{{ mac_address_mapping[dramble_mac_address].name }}"
         dramble_ip_address: "{{ mac_address_mapping[dramble_mac_address].ip }}"
 
-    - name: Set up networking-related files.
+    - name: Update /etc/hostname
       template:
-        src: "templates/{{ item.template }}"
-        dest: "{{ item.dest }}"
+        src: "templates/hostname.j2"
+        dest: "/etc/hostname"
         mode: 0644
-      with_items:
-        - { template: hostname.j2, dest: /etc/hostname }
-        - { template: hosts.j2, dest: /etc/hosts }
-        - { template: resolv.conf.j2, dest: /etc/resolv.conf }
-        - { template: dhcpcd.conf.j2, dest: /etc/dhcpcd.conf }
-      notify:
-        - update hostname
-        - delete dhcp leases
 
-  handlers:
-    - name: update hostname
-      command: "hostname {{ dramble_hostname }}"
+    - name: Run hostname command
+      command: "hostname {{ bramble_hostname }}"
 
-    - name: delete dhcp leases
-      file:
-        path: /var/lib/dhcp/dhclient.leases
-        state: absent
-      with_items:
-        - /var/lib/dhcp/dhclient.leases
-        - /var/lib/dhcpcd5/dhcpcd-eth0.lease
+    - name: Update /etc/dhcpcd.conf
+      template:
+        src: "templates/dhcpcd.conf.j2"
+        dest: "/etc/dhcpcd.conf"
+        mode: 0644
+
+    - name: Update /etc/hosts
+      template:
+        src: "templates/hosts.j2"
+        dest: "/etc/hosts"
+        mode: 0644

--- a/setup/networking/templates/dhcpcd.conf.j2
+++ b/setup/networking/templates/dhcpcd.conf.j2
@@ -61,6 +61,6 @@ slaac private
 # Bramble configuration
 
 interface eth0
-static ip_address={{ bramble_ip_address }}/24
+static ip_address={{ dramble_ip_address }}/24
 static routers={{ default_gateway }}
 static domain_name_servers={{ default_gateway }} {{ dns_nameservers | join(' ') }}

--- a/setup/networking/templates/dhcpcd.conf.j2
+++ b/setup/networking/templates/dhcpcd.conf.j2
@@ -1,15 +1,5 @@
-# Configuration for dhcpcd.
+# A sample configuration for dhcpcd.
 # See dhcpcd.conf(5) for details.
-
-interface eth0
-static ip_address={{ dramble_ip_address }}/24
-static routers=10.0.100.1
-static domain_name_servers={{ dns_nameservers | join(' ') }}
-
-interface wlan0
-static ip_address={{ dramble_ip_address }}/24
-static routers=10.0.100.1
-static domain_name_servers={{ dns_nameservers | join(' ') }}
 
 # Allow users of this group to interact with dhcpcd via the control socket.
 #controlgroup wheel
@@ -21,6 +11,8 @@ hostname
 clientid
 # or
 # Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
 #duid
 
 # Persist interface configuration when dhcpcd exits.
@@ -34,18 +26,41 @@ option rapid_commit
 # A list of options to request from the DHCP server.
 option domain_name_servers, domain_name, domain_search, host_name
 option classless_static_routes
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
 # Most distributions have NTP support.
-option ntp_servers
-# Respect the network MTU.
-# Some interface drivers reset when changing the MTU so disabled by default.
-#option interface_mtu
+#option ntp_servers
 
 # A ServerID is required by RFC2131.
 require dhcp_server_identifier
 
-# Generate Stable Private IPv6 Addresses instead of hardware based ones
+# Generate SLAAC address using the Hardware Address of the interface
+#slaac hwaddr
+# OR generate Stable Private IPv6 Addresses based from the DUID
 slaac private
 
-# A hook script is provided to lookup the hostname if not set by the DHCP
-# server, but it should not be run by default.
-nohook lookup-hostname
+# Example static IP configuration:
+#interface eth0
+#static ip_address=192.168.0.10/24
+#static ip6_address=fd51:42f8:caae:d92e::ff/64
+#static routers=192.168.0.1
+#static domain_name_servers=192.168.0.1 8.8.8.8 fd51:42f8:caae:d92e::1
+
+# It is possible to fall back to a static IP if DHCP fails:
+# define static profile
+#profile static_eth0
+#static ip_address=192.168.1.23/24
+#static routers=192.168.1.1
+#static domain_name_servers=192.168.1.1
+
+# fallback to static profile on eth0
+#interface eth0
+#fallback static_eth0
+
+# Bramble configuration
+
+interface eth0
+static ip_address={{ bramble_ip_address }}/24
+static routers={{ default_gateway }}
+static domain_name_servers={{ default_gateway }} {{ dns_nameservers | join(' ') }}

--- a/setup/networking/templates/hosts.j2
+++ b/setup/networking/templates/hosts.j2
@@ -3,7 +3,7 @@
 ff02::1		ip6-allnodes
 ff02::2		ip6-allrouters
 
-127.0.1.1 {{ bramble_hostname }}
+127.0.1.1 {{ dramble_hostname }}
 
 {% for (key, value) in mac_address_mapping.items() %}
 {{ value.ip }} {{ value.name.split('.')[0] }} {{ value.name }}

--- a/setup/networking/templates/hosts.j2
+++ b/setup/networking/templates/hosts.j2
@@ -3,7 +3,7 @@
 ff02::1		ip6-allnodes
 ff02::2		ip6-allrouters
 
-127.0.1.1 {{ gramble_hostname }}
+127.0.1.1 {{ bramble_hostname }}
 
 {% for (key, value) in mac_address_mapping.items() %}
 {{ value.ip }} {{ value.name.split('.')[0] }} {{ value.name }}

--- a/setup/networking/templates/hosts.j2
+++ b/setup/networking/templates/hosts.j2
@@ -1,13 +1,10 @@
-127.0.0.1 localhost
-::1   localhost ip6-localhost ip6-loopback
-fe00::0   ip6-localnet
-ff00::0   ip6-mcastprefix
-ff02::1   ip6-allnodes
-ff02::2   ip6-allrouters
+127.0.0.1	localhost
+::1		    localhost ip6-localhost ip6-loopback
+ff02::1		ip6-allnodes
+ff02::2		ip6-allrouters
 
-127.0.1.1 {{ dramble_hostname }}
+127.0.1.1 {{ gramble_hostname }}
 
-{# Add an entry for each host in the cluster, using the loop index to map IPs #}
-{% for host in groups['dramble'] %}
-10.0.100.{{ 60 + loop.index }} kube{{ loop.index }} kube{{ loop.index }}.pidramble.com
+{% for (key, value) in mac_address_mapping.items() %}
+{{ value.ip }} {{ value.name.split('.')[0] }} {{ value.name }}
 {% endfor %}

--- a/setup/networking/templates/resolv.conf.j2
+++ b/setup/networking/templates/resolv.conf.j2
@@ -1,4 +1,0 @@
-options timeout:1 attempts:1
-{% for nameserver in dns_nameservers %}
-nameserver {{ nameserver }}
-{% endfor %}


### PR DESCRIPTION
Several updates here:

Added:
* Smarter way of building `/etc/hosts`, loops thru `mac_address_mapping` to populate hosts
* New `default_gateway` var to set router/default gateway in `/etc/dhcpcd.conf.j2` and appends as a dns server
* Bash script to run local to get IP addresses from Mac Addresses

Removed:
* `/etc/resolv.conf`- this is handled in `/etc/dhcpcd.conf.j2`
* Flushing DNS - in my testing this did nothing

Changed:
* `/etc/dhcpcd.conf.j2` is now using Raspbian Busters file
* Broke out tasks in `main.yml` to their own task instead of looping thru the templates. This allows us to build `/etc/hosts` with `mac_address_mapping` and not have duplicate entrys in `/etc/hosts`
* Set default DNS servers to Cloudflare instead of Googles servers