### PR TITLE
Remove extraneous code

### DIFF
--- a/tasks/cgroup-features.yml
+++ b/tasks/cgroup-features.yml
@@ -3,7 +3,6 @@
   lineinfile:
     path: /boot/cmdline.txt
     backrefs: True
-    # regexp: '(^.+console(\s+(?!cgroup_enable=cpuset)[\w=/\-\.]+)*)\s*$'
     regexp: '(^.+rootwait(\s+(?!cgroup_enable=cpuset cgroup_enable=memory)[\w=/\-\.]+)*)\s*$'
     line: '\1 cgroup_enable=cpuset cgroup_enable=memory'
     state: present


### PR DESCRIPTION
I was reading through the bramble source code (due to hearing about this project through the k8s podcast by Google!) and spotted this commented out line. It looks like the `regexp` may have evolved but this might be a vestigial piece of code evolution.

Thanks for doing what you do in the community! I appreciate your presence in the ansible community. Cheers 🍻 