### PR TITLE
adding option to upgrade python interpreter to 3

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -27,3 +27,6 @@ docker_registry_http_secret: fdb19409c851605cd6c46615888d4c0e37858121df7c
 # LED Configuration.
 led_enable_gpio: false
 led_enable_blinkstick: false
+
+# Set Python3 as the default ansible_interpreter ( for Pis without python 2.7 )
+ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
With the deprecation of python 2, this configuration allows you to have the main task for provisioning the pis to use python3 by default. 

This isn't an issue on older Raspbian releases but with the most recent releases of Raspbian Buster, python 2 is no longer included by default. 
https://www.debian.org/releases/stable/i386/release-notes/ch-information.en.html