### PR TITLE
Add check for directory path before attempting to create dd file

### DIFF
--- a/setup/benchmarks/disk-benchmark.sh
+++ b/setup/benchmarks/disk-benchmark.sh
@@ -30,6 +30,11 @@ USER_HOME_PATH=$(getent passwd $SUDO_USER | cut -d: -f6)
 IOZONE_INSTALL_PATH=$USER_HOME_PATH
 IOZONE_VERSION=iozone3_489
 
+# Create directory if it does not already exist
+if [ ! -d $DEVICE_MOUNT_PATH ]; then
+  mkdir -p $DEVICE_MOUNT_PATH
+fi
+
 cd $IOZONE_INSTALL_PATH
 
 # Install dependencies.


### PR DESCRIPTION
I added an if statement to create the file path for the test if it didn't already exist. On my system (just using the benchmark script, and not the rest of the package) it failed to execute the dd command as the directory wasn't there. 